### PR TITLE
Add TurtleCoind API, and expand descriptions

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,7 +77,7 @@
 											<p>What would a contest be without rules? We have a few, and we think you'll find them to be fair:</p>
 											<li>Teams may be one or many individuals, named or anonymous. Individuals can be part of one or many teams.  </li>
 											<li>Contest starts on December 1, ends December 9, 2019. All teams must register before December 1.  </li>
-											<li>no gambling, or market-related stuff.  </li>
+											<li>No gambling, or market-related stuff.  </li>
 										</ul>
 										<a href="https://forms.gle/bsMpMQbXxh88Lxdu6" class="special">Register your team here</a>
 									</div>
@@ -94,17 +94,28 @@
 										<p>The development side of this contest will be tasked with creating a project that highlights any one of the recent technologies we've brought to the community this year.</p>
 										<p>
 											<strong>
-												<a href="https://github.com/turtlecoin/turtlecoin" class="special">WALLET-API</a>
-											</strong> An API interface for wallets on the TRTL Network
+												<a href="https://turtlecoin.github.io/wallet-api-docs" class="special">WALLET-API</a>
+											</strong> A REST API interface for wallets on the TRTL Network. Send and receive transactions with a high performance C++ backend.
 										</p>
 										<p>
 											<strong>
-												<a href="https://www.npmjs.com/package/turtlecoin-wallet-backend" class="special">BACKEND-JS & TURTLECOIN-UTILS</a>
-											</strong> Backend Javascript wallet utilities for the TRTL Network
+												<a href="https://github.com/turtlecoin/turtlecoin-wallet-backend-js" class="special">TURTLECOIN WALLET BACKEND</a>
+											</strong> A full wallet implementation and library usable both in the web and nodeJS, in native JavaScript. Powers both Proton and TonChan.
+										</p>
+                                        <p>
+											<strong>
+												<a href="https://github.com/turtlecoin/turtlecoin-utils" class="special">TURTLECOIN UTILS</a>
+											</strong> Low level cryptography utilities providing wallet creation, transaction scanning, transaction creation, and more, in native JavaScript.
 										</p>
 										<p>
 											<strong>
-												<a href="https://turtlepay.io/" class="special">TurtlePay®</a></strong> Remotely hosted payments gateway for TRTL
+												<a href="https://turtlepay.io/" class="special">TurtlePay®</a>
+                                            </strong> Remotely hosted payments gateway for TRTL. Securely receive funds without having to run any software.
+										</p>
+                                        <p>
+											<strong>
+												<a href="https://docs.turtlecoin.lol/developer/api/daemon-json-rpc-api" class="special">TurtleCoind API</a>
+                                            </strong> Build rich applications by directly interacting with a full TurtleCoin node. Retrieve detailed block data, submit mined blocks, and more.
 										</p>
 									</div>
 								</div>


### PR DESCRIPTION
* Add TurtleCoind to the list of allowed technologies
* Split turtlecoin-utils and turtlecoin-wallet-backend into their own entries
* Expand the descriptions on what each technology can do

Feel free to reject/request changes on my wording changes. I wanted to make it clear from a glance which niche each project fulfills, but it may be a bit wordy for your liking.